### PR TITLE
Korraga saab saata kuni 2 sõnumit

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -72,7 +72,7 @@ Client.prototype._sendRequest = function _sendRequest (method, action, payload, 
   }
 
   var self = this;
-  var endpoints = Client._ENDPOINTS;
+  var endpoints = [].concat(Client._ENDPOINTS || []);
 
   function request (endpoint) {
     var data = null;


### PR DESCRIPTION
Kuna API endpointide massiiv on päringute vahel jagatud ning iga uue päringu korral tehakse sellele massiivile .shift(), siis on võimalik teha täpselt niipalju päringuid kuni on massiivis elemente – ehk 2. Peale seda on kõikide päringute vastuseks "Unable to connect API endpoint".

See pull request muudab moodulit nii, et enam ei kasutata päringu tegemiseks jagatud vaid kloonitud masiivi ning .shift() midagi ära enam ei riku.
